### PR TITLE
Use compile definitions to pass build info

### DIFF
--- a/othello_cpp/.gitignore
+++ b/othello_cpp/.gitignore
@@ -45,8 +45,5 @@ othello_cpp/x86/
 # Build dirs
 cmake-build-*/
 
-# Version header
-src/version.hpp
-
 # CMake
 CMakeSettings.json

--- a/othello_cpp/CMakeLists.txt
+++ b/othello_cpp/CMakeLists.txt
@@ -34,20 +34,14 @@ set(BUILD_NAME "othello_cpp_${CMAKE_PROJECT_VERSION}_${GIT_HASH}_${TIMESTAMP}")
 message(STATUS "Build name: ${BUILD_NAME}")
 
 # Create version info
-set(VERSION_HEADER
-"#pragma once
-namespace version
-{
-constexpr auto APP_NAME = \"${CMAKE_PROJECT_NAME}\";
-constexpr auto BRANCH = \"${GIT_BRANCH}\";
-constexpr auto BUILD_NAME = \"${BUILD_NAME}\";
-constexpr auto COMMIT = \"${GIT_HASH}\";
-constexpr auto DATE = \"${DATE}\";
-constexpr auto VERSION_NUMBER = \"${CMAKE_PROJECT_VERSION}\";
-}  // namespace version
-"
+add_compile_definitions(
+    BUILDTIME_APP_NAME="${CMAKE_PROJECT_NAME}"
+    BUILDTIME_BRANCH="${GIT_BRANCH}"
+    BUILDTIME_BUILD_NAME="${BUILD_NAME}"
+    BUILDTIME_COMMIT="${GIT_HASH}"
+    BUILDTIME_DATE="${DATE}"
+    BUILDTIME_VERSION_NUMBER="${CMAKE_PROJECT_VERSION}"
 )
-file(WRITE ${CMAKE_SOURCE_DIR}/src/version.hpp "${VERSION_HEADER}")
 
 # ccache
 # https://ccache.dev/

--- a/othello_cpp/src/version.hpp
+++ b/othello_cpp/src/version.hpp
@@ -1,0 +1,10 @@
+#pragma once
+namespace version
+{
+constexpr auto APP_NAME = BUILDTIME_APP_NAME;
+constexpr auto BRANCH = BUILDTIME_BRANCH;
+constexpr auto BUILD_NAME = BUILDTIME_BUILD_NAME;
+constexpr auto COMMIT = BUILDTIME_COMMIT;
+constexpr auto DATE = BUILDTIME_DATE;
+constexpr auto VERSION_NUMBER = BUILDTIME_VERSION_NUMBER;
+}  // namespace version


### PR DESCRIPTION
Motivation here is pretty obvious - no syntax mixing, no source code generation.

Drawbacks:
- ccache efficiency will probably to go down